### PR TITLE
Fix #56, open button not working

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -60,6 +60,10 @@ pkgs.stdenv.mkDerivation rec {
   '';
 
   postInstall = ''
-    wrapProgram $out/bin/nix-software-center --prefix PATH : '${lib.makeBinPath [ pkgs.gnome-console pkgs.sqlite ]}'
+    wrapProgram $out/bin/nix-software-center --prefix PATH : '${lib.makeBinPath [
+      pkgs.gnome-console
+      pkgs.gtk3 # provides gtk-launch
+      pkgs.sqlite
+    ]}'
   '';
 }


### PR DESCRIPTION
Adds gtk3 to the wrapper (needed to fix #56 ) since `gtk-launch` is not available on all distributions (e.g. KDE Plasma). Note that gtk4 does not provide gtk-launch, a binary gtk4-launch exists only in the `.dev` version… not sure if it is better to use it. See also this conversation https://discourse.nixos.org/t/gtk4-only-available-through-nix-shell/15997/6