### PR TITLE
Remove an IFD when importing nixos-appstream-data.

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,17 +1,14 @@
 { pkgs ? import <nixpkgs> { }
 , lib ? import <nixpkgs/lib>
-}:
-let
-  nixos-appstream-data = (import
-    (pkgs.fetchFromGitHub {
-      owner = "vlinkz";
-      repo = "nixos-appstream-data";
-      rev = "66b3399e6d81017c10265611a151d1109ff1af1b";
-      hash = "sha256-oiEZD4sMpb2djxReg99GUo0RHWAehxSyQBbiz8Z4DJk=";
-    })
-    { set = "all"; stdenv = pkgs.stdenv; lib = pkgs.lib; pkgs = pkgs; });
-in
-pkgs.stdenv.mkDerivation rec {
+, nixos-appstream-data ? (import
+  (pkgs.fetchFromGitHub {
+    owner = "vlinkz";
+    repo = "nixos-appstream-data";
+    rev = "66b3399e6d81017c10265611a151d1109ff1af1b";
+    hash = "sha256-oiEZD4sMpb2djxReg99GUo0RHWAehxSyQBbiz8Z4DJk=";
+  })
+  { set = "all"; stdenv = pkgs.stdenv; lib = pkgs.lib; pkgs = pkgs; })
+}: pkgs.stdenv.mkDerivation rec {
   pname = "nix-software-center";
   version = "0.1.2";
 

--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,29 @@
 {
   "nodes": {
+    "nixos-appstream-data": {
+      "inputs": {
+        "flake-utils": [
+          "utils"
+        ],
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1712858390,
+        "narHash": "sha256-XE7gr+zU3N4SHPAhsgk8cVAFp1iBg+Lxxp3y4dUF1vE=",
+        "owner": "korfuri",
+        "repo": "nixos-appstream-data",
+        "rev": "0465d42a4433faa63b7a5eb0b8d397937c9fc13a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "korfuri",
+        "ref": "flake",
+        "repo": "nixos-appstream-data",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1692638711,
@@ -18,6 +42,7 @@
     },
     "root": {
       "inputs": {
+        "nixos-appstream-data": "nixos-appstream-data",
         "nixpkgs": "nixpkgs",
         "utils": "utils"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -2,25 +2,24 @@
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
     utils.url = "github:numtide/flake-utils";
+    nixos-appstream-data = {
+      url = "github:korfuri/nixos-appstream-data/flake";
+      inputs.nixpkgs.follows = "nixpkgs";
+      inputs.flake-utils.follows = "utils";
+    };
   };
 
-  outputs = { self, nixpkgs, utils, ... }:
+  outputs = { self, nixpkgs, utils, nixos-appstream-data, ... }:
     utils.lib.eachDefaultSystem (system:
       let
         pkgs = import nixpkgs {
           inherit system;
         };
-        nixos-appstream-data = pkgs.fetchFromGitHub {
-          owner = "vlinkz";
-          repo = "nixos-appstream-data";
-          rev = "66b3399e6d81017c10265611a151d1109ff1af1b";
-          hash = "sha256-oiEZD4sMpb2djxReg99GUo0RHWAehxSyQBbiz8Z4DJk=";
-        };
       in
       rec
       {
         packages = let
-          nix-software-center = pkgs.callPackage ./default.nix {};
+          nix-software-center = pkgs.callPackage ./default.nix { inherit (nixos-appstream-data.packages."${system}") nixos-appstream-data; };
         in {
           inherit nix-software-center;
           default = nix-software-center;
@@ -54,7 +53,7 @@
             polkit
             sqlite
             wrapGAppsHook4
-            nixos-appstream-data
+            nixos-appstream-data.packages."${system}".nixos-appstream-data
           ];
           RUST_SRC_PATH = "${pkgs.rust.packages.stable.rustPlatform.rustLibSrc}";
         };


### PR DESCRIPTION
I recently added a flake for nixos-appstream-data. This allows us to depend on that flake instead of doing an IFD to load its default.nix.

An IFD in nix-software-center is problematic for users who use flakes and have multiple nixos configurations with different architectures. Because of https://github.com/NixOS/nix/issues/4265 this causes `nix flake check` to fail for them.

Note that users of nix-software-center that do not rely on the flake will still need an IFD. I'm not aware of a better way (other than upstreaming both in nixpkgs).

Ref: https://github.com/snowfallorg/nixos-appstream-data/pull/1