### PR TITLE
Update util.rs to remove 1 s

### DIFF
--- a/src/parse/util.rs
+++ b/src/parse/util.rs
@@ -1,3 +1,3 @@
 pub fn checkonline() -> bool {
-    reqwest::blocking::get("https://nmcheck.gnome.org/check_network_status.txt").is_ok()
+    reqwest::blocking::get("http://nmcheck.gnome.org/check_network_status.txt").is_ok()
 }


### PR DESCRIPTION
this hopefully temporarily fixes the bug where no-internet connection message is shown when user has internet which one commenter pointed out is probably due to a expired certificate
https://github.com/snowfallorg/nix-software-center/issues/75#issuecomment-2480176559
we should really consider just checking if some huge website like google.com is online 