### PR TITLE
`gnome.adwaita-icon-theme` became `pkgs.adwata-icon-theme`

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -46,7 +46,7 @@
     libxml2
     openssl
     wayland
-    gnome.adwaita-icon-theme
+    adwaita-icon-theme
     desktop-file-utils
     nixos-appstream-data
   ];

--- a/default.nix
+++ b/default.nix
@@ -58,7 +58,7 @@
 
   postInstall = ''
     wrapProgram $out/bin/nix-software-center --prefix PATH : '${lib.makeBinPath [
-      pkgs.gnome-console
+      pkgs.kitty
       pkgs.gtk3 # provides gtk-launch
       pkgs.sqlite
     ]}'


### PR DESCRIPTION
Fix error when building nix:
`error: The ‘gnome.adwaita-icon-theme’ was moved to top-level. Please use ‘pkgs.adwaita-icon-theme’ directly.`

Apply for nixpkgs >= 24.11